### PR TITLE
Updated UMI Script

### DIFF
--- a/New-UmiDeployment.ps1
+++ b/New-UmiDeployment.ps1
@@ -1,32 +1,42 @@
-#Ensure the right subscription context is created
-$subscription = '<Customer New Subscription>'
-$affiliatePrefix = "<Txxxx>"
+
+# Connect to the right subscription
+
+do {
+  $customerPrefix = Read-Host "Enter customer prefix name: "
+} while ($customerPrefix.Length -lt 3)
+
+do {
+  $subscription = Read-Host "Enter the subscription id: "
+} while ($subscription.Length -lt 36)
+
 $context = Set-AzContext -Subscription $subscription
 
-# Change CustomerName to the name of the SOC customer
-$umiName = "MSSP-RSOC-Sentinel-Ingestion-UMI"
+$umiName = "MSSP-Sentinel-Ingestion-UMI"
+$azRegion = "eastus"
+$rg = "$($customerPrefix)-Sentinel-Prod-rg"
+
 # Add required Azure Resource Providers
 Register-AzResourceProvider -ProviderNamespace Microsoft.Insights
 Register-AzResourceProvider -ProviderNamespace Microsoft.ManagedServices
 Register-AzResourceProvider -ProviderNamespace Microsoft.ManagedIdentity
 # Default resource group for managed identities
-$rg = "$($affiliatePrefix)-Sentinel-Prod-rg"
-$azRegion = "eastus" # this should match your deployment region and should only be: eastus, eastus2, westus2, australiacentral, brazilsouth, southeastasia
+
 $graphAppId = "00000003-0000-0000-c000-000000000000" # Don't change this.
 
 # Graph API permissions to set
 $addPermissions = @(
   "Application.ReadWrite.OwnedBy"
 )
-$SubscriptionId = (Get-AzContext).Subscription.Id
-$scope = "/subscriptions/$($SubscriptionId)"
-$azureOwnerRoleId = "8e3af657-a8ff-443c-a75c-2fe8c4bcb635" # This is Owner but can be set to whatever is needed.
-$azureKVAdminRoleId = "00482a5a-887f-4fb3-b363-3b7fe8e74483" # This is Owner but can be set to whatever is needed.
-$azureKVUserRoleId = "4633458b-17de-408a-b874-0445c86b69e6" # This is Owner but can be set to whatever is needed.
+
+$subscriptionId = (Get-AzContext).Subscription.Id
+$scope = "/subscriptions/$($subscriptionId)"
+$azureOwnerRoleId = "8e3af657-a8ff-443c-a75c-2fe8c4bcb635" # This is Owner.
+$azureKVAdminRoleId = "00482a5a-887f-4fb3-b363-3b7fe8e74483" # This is Key Vault Administrator.
+$azureKVUserRoleId = "4633458b-17de-408a-b874-0445c86b69e6" # This is Key Vault Secrets User.
 
 # Create resource group if needed.
 if ([string]::IsNullOrEmpty((Get-AzResourceGroup -Name $rg -ErrorAction SilentlyContinue))) {
-    New-AzResourceGroup -Name $rg -Location $azRegion
+  New-AzResourceGroup -Name $rg -Location $azRegion
 }
 
 # Create user managed identity
@@ -34,7 +44,7 @@ $null = New-AzUserAssignedIdentity -Name $umiName -ResourceGroupName $rg -Locati
 $umi = Get-AzAdServicePrincipal -DisplayName $umiName
 # assign permissions to allow creating service principals.
 $graphSP = Get-AzADServicePrincipal -appId $graphAppId
-$appRoles = $graphSP.AppRole | Where-Object {($_.Value -in $addPermissions) -and ($_.AllowedMemberType -contains "Application")}
+$appRoles = $graphSP.AppRole | Where-Object { ($_.Value -in $addPermissions) -and ($_.AllowedMemberType -contains "Application") }
 
 Connect-AzureAD -TenantId $context.Tenant.Id
 # If Connect-AzureAd does not work, run 'Connect-AzureAD -TenantId <CustomerTenantId>'

--- a/New-UmiDeployment.ps1
+++ b/New-UmiDeployment.ps1
@@ -116,17 +116,17 @@ $appRoles = $graphSP.AppRoles |
   Where-Object { ($_.Value -in $addPermissions) -and ($_.AllowedMemberTypes -contains 'Application') }
 
 $appRoles | ForEach-Object {
-  New-MgServicePrincipalAppRoleAssignment -ResourceId $graphSP.Id -PrincipalId $umiId -AppRoleId $_.Id -ServicePrincipalId $umiId
+  New-MgServicePrincipalAppRoleAssignment -ResourceId $graphSP.Id -PrincipalId $umi.Id -AppRoleId $_.Id -ServicePrincipalId $umi.Id
 }
 
 # Make sure the UMI is set as the owner of the application. This is required to allow
 # the UMI to manage the app registration.
 $newOwner = @{
-  '@odata.id' = "https://graph.microsoft.com/v1.0/directoryObjects/{$($Umi.Id)}"
+  '@odata.id' = "https://graph.microsoft.com/v1.0/directoryObjects/$($umi.Id)"
 }
 
 # This adds the UMI as an owner to application
-New-MgApplicationOwnerByRef -ApplicationId $Id -BodyParameter $newOwner
+New-MgApplicationOwnerByRef -ApplicationId $adsp.Id -BodyParameter $newOwner
 
 # This will update the name to be in line with our new standard name
 Update-MgApplication -ApplicationId $Id -DisplayName 'MSSP-Sentinel-Ingestion'

--- a/New-UmiDeployment.ps1
+++ b/New-UmiDeployment.ps1
@@ -1,38 +1,63 @@
+<#
+.SYNOPSIS
+  Deploys a User Managed Identity (UMI) for Sentinel ingestion.
+.DESCRIPTION
+  This script deploys a User Managed Identity (UMI) for Sentinel ingestion. It creates a resource group,
+  registers the required Azure Resource Providers, installs the required PowerShell modules, and assigns
+  permissions to the UMI. It also creates a service principal and assigns the required permissions for
+  the UMI to manage the service principal.
+.PARAMETER CustomerPrefix
+  The customer prefix name. This is used to create the resource group name.
+.PARAMETER SubscriptionId
+  The subscription ID where the UMI will be deployed.
+.PARAMETER AzRegion
+  The Azure region where the UMI will be deployed. Default is 'eastus'.
 
-# Connect to the right subscription
+#>
+[CmdletBinding()]
+param (
+  [Parameter()]
+  [string] $CustomerPrefix,
+  [Parameter()]
+  [string] $Subscription,
+  [Parameter()]
+  [string] $AzRegion = 'eastus'
+)
 
-do {
-  $customerPrefix = Read-Host "Enter customer prefix name: "
-} while ($customerPrefix.Length -lt 3)
-
-do {
-  $subscription = Read-Host "Enter the subscription id: "
-} while ($subscription.Length -lt 36)
-
-$context = Set-AzContext -Subscription $subscription
-
-$umiName = "MSSP-Sentinel-Ingestion-UMI"
-$azRegion = "eastus"
-$rg = "$($customerPrefix)-Sentinel-Prod-rg"
+# Install the required PowerShell modules
+Install-Module Az.Resources -Scope CurrentUser -SkipPublisherCheck -Force -AllowClobber -AcceptLicense
+Install-Module Microsoft.Graph.Authentication -Scope CurrentUser -SkipPublisherCheck -Force -AllowClobber -AcceptLicense
+Install-Module Microsoft.Graph.Applications -Scope CurrentUser -SkipPublisherCheck -Force -AllowClobber -AcceptLicense
 
 # Add required Azure Resource Providers
 Register-AzResourceProvider -ProviderNamespace Microsoft.Insights
 Register-AzResourceProvider -ProviderNamespace Microsoft.ManagedServices
 Register-AzResourceProvider -ProviderNamespace Microsoft.ManagedIdentity
-# Default resource group for managed identities
 
-$graphAppId = "00000003-0000-0000-c000-000000000000" # Don't change this.
+do {
+  $customerPrefix = Read-Host 'Enter customer prefix name: '
+} while ($customerPrefix.Length -lt 3)
 
-# Graph API permissions to set
-$addPermissions = @(
-  "Application.ReadWrite.OwnedBy"
-)
+do {
+  $Subscription = Read-Host 'Enter the subscription id: '
+} while ($Subscription.Length -lt 36)
 
+$umiName = 'MSSP-Sentinel-Ingestion-UMI'
+$rg = "$($customerPrefix.ToUpper())-Sentinel-Prod-rg"
+
+# If running locally, instead of cloud shell, you will need to authenticate to Azure.
+# Connect-AzAccount
+Set-AzContext -SubscriptionId $Subscription
+
+# Get the context of the current subscription
 $subscriptionId = (Get-AzContext).Subscription.Id
 $scope = "/subscriptions/$($subscriptionId)"
-$azureOwnerRoleId = "8e3af657-a8ff-443c-a75c-2fe8c4bcb635" # This is Owner.
-$azureKVAdminRoleId = "00482a5a-887f-4fb3-b363-3b7fe8e74483" # This is Key Vault Administrator.
-$azureKVUserRoleId = "4633458b-17de-408a-b874-0445c86b69e6" # This is Key Vault Secrets User.
+
+# Azure RBAC role IDs needed
+$azureOwnerRoleId = '8e3af657-a8ff-443c-a75c-2fe8c4bcb635' # This is Owner.
+$azureKVAdminRoleId = '00482a5a-887f-4fb3-b363-3b7fe8e74483' # This is Key Vault Administrator.
+$azureKVUserRoleId = '4633458b-17de-408a-b874-0445c86b69e6' # This is Key Vault Secrets User.
+$metricsPubRoleId = '3913510d-42f4-4e42-8a64-420c390055eb' # This is Monitoring Metrics Publisher.
 
 # Create resource group if needed.
 if ([string]::IsNullOrEmpty((Get-AzResourceGroup -Name $rg -ErrorAction SilentlyContinue))) {
@@ -41,29 +66,67 @@ if ([string]::IsNullOrEmpty((Get-AzResourceGroup -Name $rg -ErrorAction Silently
 
 # Create user managed identity
 $null = New-AzUserAssignedIdentity -Name $umiName -ResourceGroupName $rg -Location $AzRegion
-$umi = Get-AzAdServicePrincipal -DisplayName $umiName
-# assign permissions to allow creating service principals.
-$graphSP = Get-AzADServicePrincipal -appId $graphAppId
-$appRoles = $graphSP.AppRole | Where-Object { ($_.Value -in $addPermissions) -and ($_.AllowedMemberType -contains "Application") }
+$umi = Get-AzADServicePrincipal -DisplayName $umiName
 
-Connect-AzureAD -TenantId $context.Tenant.Id
-# If Connect-AzureAd does not work, run 'Connect-AzureAD -TenantId <CustomerTenantId>'
+# Wait for the UMI to be created
 Start-Sleep 10
 
-# Assign User Assigned Identity Owner permissions to the subscription 
+# Assign User Assigned Identity Owner permissions to the subscription
 New-AzRoleAssignment -RoleDefinitionId $azureOwnerRoleId -ObjectId $umi.Id -Scope $scope
-Start-Sleep 5
+
+# Assign Key Vault permissions to the UMI
+# The UMI needs to be able to manage Key Vaults, so we assign it the
 New-AzRoleAssignment -RoleDefinitionId $azureKVAdminRoleId -ObjectId $umi.Id -Scope $scope
-Start-Sleep 5
+
+# Assign Key Vault Secrets User permissions to the UMI
+# The UMI needs to be able to read secrets from Key Vaults, so we assign it the Key Vault Secrets User role.
+# This role allows the UMI to read secrets from Key Vaults, which is necessary for its operation.
 New-AzRoleAssignment -RoleDefinitionId $azureKVUserRoleId -ObjectId $umi.Id -Scope $scope
-Start-Sleep 5
 
-# This requires permissions to assign app roles so may need to be rerun by an administrator. Have them run the following
-#Connect-AzureAD -TenantId $context.Tenant.Id
+# Wait for the role assignments to propagate
+Start-Sleep 15
 
-# Graph API permissions to set
+# Create the service principal/app registration
+$appName = "MSSP-Sentinel-Ingestion"
+New-AzADServicePrincipal -DisplayName $appName
+Start-Sleep 20
+$adsp = Get-AzADServicePrincipal -DisplayName $appName
+
+# Assign the UMI Monitoring Metrics Publisher role to the subscription.
+# This role is required to allow the UMI to publish data to Azure Sentinel/Azure Monitor.
+New-AzRoleAssignment -RoleDefinitionId $metricsPubRoleId -ObjectId $adsp.Id -Scope $subscriptionId
+
+# The UMI needs to be granted permissions to the Microsoft Graph API
+# to allow it to view and manage its owned resources in the tenant.
+
+# Connect to Microsoft Graph. You will need to complete the authentication outside the shell.
+Connect-MgGraph -Scopes 'Application.ReadWrite.All', 'Directory.Read.All', 'AppRoleAssignment.ReadWrite.All' -NoWelcome
+
+# Get the Service Principal for Microsoft Graph
+$graphSP = Get-MgServicePrincipal -Filter "AppId eq '00000003-0000-0000-c000-000000000000'"
+
+# Graph API permissions to assign to the UMI
+# This allows the UMI to manage its service principal
 $addPermissions = @(
-  "Application.ReadWrite.OwnedBy"
+  'Application.ReadWrite.OwnedBy',
+  'Application.Read.All'
 )
 
-$appRoles | ForEach-Object { New-AzureAdServiceAppRoleAssignment -ObjectId $umi.Id -PrincipalId $umi.Id -ResourceId $graphSp.Id -Id $_.Id }
+$appRoles = $graphSP.AppRoles |
+  Where-Object { ($_.Value -in $addPermissions) -and ($_.AllowedMemberTypes -contains 'Application') }
+
+$appRoles | ForEach-Object {
+  New-MgServicePrincipalAppRoleAssignment -ResourceId $graphSP.Id -PrincipalId $umi.Id -AppRoleId $_.Id -ServicePrincipalId $umi.Id
+}
+
+# Make sure the UMI is set as the owner of the application. This is required to allow
+# the UMI to manage the app registration.
+$newOwner = @{
+  '@odata.id' = "https://graph.microsoft.com/v1.0/directoryObjects/{$($umi.Id)}"
+}
+
+# This adds the UMI as an owner to application
+New-MgApplicationOwnerByRef -ApplicationId $Id -BodyParameter $newOwner
+
+# This will update the name to be in line with our new standard name
+Update-MgApplication -ApplicationId $Id -DisplayName 'MSSP-Sentinel-Ingestion'

--- a/New-UmiDeployment.ps1
+++ b/New-UmiDeployment.ps1
@@ -128,5 +128,3 @@ $newOwner = @{
 # This adds the UMI as an owner to application
 New-MgApplicationOwnerByRef -ApplicationId $adsp.Id -BodyParameter $newOwner
 
-# This will update the name to be in line with our new standard name
-Update-MgApplication -ApplicationId $Id -DisplayName 'MSSP-Sentinel-Ingestion'

--- a/Readme.md
+++ b/Readme.md
@@ -5,7 +5,7 @@ Links to deploy custom template for lighthouse authorizations:
     <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fjpanderson91%2Flighthouse%2Frefs%2Fheads%2Fmain%2Flighthouseauthorizations.json/createUIDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2Fjpanderson91%2Flighthouse%2Frefs%2Fheads%2Fmain%2Flighthouseauthorizationsui.json" target="_blank"><img src="https://aka.ms/deploytoazurebutton"/>
 
 2. [UMI Deployment script](New-UmiDeployment.ps1)
-3. Deploy custom template for Service Principals deployment:
+
+3. Deploy custom template for Service Principals deployment (Now handled by the UMI Deployment script):
 
     <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fjpanderson91%2Flighthouse%2Frefs%2Fheads%2Fmain%2Fspdeployment.json" target="_blank"><img src="https://aka.ms/deploytoazurebutton"/>
-

--- a/spdeployment.json
+++ b/spdeployment.json
@@ -12,7 +12,6 @@
         }
     },
     "variables": {
-        // This should be customized in the template to reflect the naming standard.
         "appRegistrationDisplayName": "MSSP-Sentinel-Ingestion"
     },
     "resources": [

--- a/spdeployment.json
+++ b/spdeployment.json
@@ -8,12 +8,12 @@
         },
         "userAssignedIdentityName": {
             "type": "String",
-            "defaultValue": "MSSP-RSOC-Sentinel-Ingestion-UMI"
+            "defaultValue": "MSSP-Sentinel-Ingestion-UMI"
         }
     },
     "variables": {
         // This should be customized in the template to reflect the naming standard.
-        "appRegistrationDisplayName": "MSSP-RSOC-Sentinel-Ingestion"
+        "appRegistrationDisplayName": "MSSP-Sentinel-Ingestion"
     },
     "resources": [
         {


### PR DESCRIPTION
## PowerShell Script Improvements (`New-UmiDeployment.ps1`):

-Corrected the usage of $umiId and $Id to $umi.Id and $adsp.Id where appropriate, improving consistency and fixing potential bugs.
-Adjusted the construction of the new owner object for clarity and to ensure the correct variable is referenced.
-Removed an unnecessary Update-MgApplication operation, likely because the display name update is now managed elsewhere or is redundant.

## Readme Updates:

- Clarified that Service Principal deployment is now handled by the UMI Deployment script.
- Updated the related section and kept the Azure deployment button, ensuring documentation is up-to-date and less confusing for users.

## ARM Template (`spdeployment.json`):

-Removed a comment regarding customizing the display name, likely because the template now uses a standard naming convention.